### PR TITLE
Adjustements to CBRAIN integration

### DIFF
--- a/boutiques_descriptors/pylossless_0.1.json
+++ b/boutiques_descriptors/pylossless_0.1.json
@@ -34,7 +34,7 @@
             "name": "Output Directory",
             "optional": true,
             "description": "Output directory",
-            "path-template": "derivatives/pylossless"
+            "path-template": "[OUTPUT_PATH]/derivatives/pylossless"
         }
 
     ],
@@ -44,6 +44,11 @@
     },
     "custom": {
         "cbrain:author": "Tyler Collins <collins.tyler.k@gmail.com>",
-        "cbrain:readonly-input-files": true
+        "cbrain:readonly-input-files": true,
+        "cbrain:integrator_modules": {
+            "BoutiquesInputValueFixer": {
+                "output_path": "cbrain_py_out"
+            }
+        }
     }
 }


### PR DESCRIPTION
This modification affects the tool when run through CBRAIN with Boutiques. The input field for the path for the output is completely hidden from the user, since anyway it's not even used in naming the actual output file. Internally, the tool is run with `./cbrain_py_out` as the path of the output to create. This will be a folder completely inside the work directory of the CBRAIN task.

Outside of CBRAIN, and with boutiques, nothing changes and the user is still allowed to provide any path that they want.